### PR TITLE
Add remark on self-generated private key and unsigned certificate

### DIFF
--- a/docker/james/README.md
+++ b/docker/james/README.md
@@ -4,3 +4,6 @@
 - Able to connect using Thunderbird using IP address (172.17.0.xx) and port 
   numbers (IMAP: 993, SMTP: 465)
 - Able to send mails between 2 users on the same JAMES server
+- `private.key` and `private.csr` are self-generated unsigned certificate for
+  one-time testing only
+ 


### PR DESCRIPTION
For one-time testing TLS/SSL only.
No security leak.