### PR TITLE
Move DateTimeKind to separate namespace

### DIFF
--- a/cpp/FileMeta/ExifToolWrapper.cpp
+++ b/cpp/FileMeta/ExifToolWrapper.cpp
@@ -444,7 +444,7 @@ namespace ExifToolWrapper
         // No garbage collector in C++
     }
     
-    BOOL ExifTool::TryParseDate(const std::string s, const DateTimeKind kind, const LPSYSTEMTIME date)
+    BOOL ExifTool::TryParseDate(const std::string s, const DateTimeKind::DateTimeKind kind, const LPSYSTEMTIME date)
     {
         // Need to make a writable copy.
         LPCTSTR ro = s.c_str();
@@ -563,10 +563,10 @@ namespace ExifToolWrapper
         
         switch (kind)
         {
-            case Unspecified:
+            case DateTimeKind::Unspecified:
                 // Skip any time conversion.
                 break;
-            case Utc:
+            case DateTimeKind::Utc:
                 SYSTEMTIME local;
                 if ( SystemTimeToTzSpecificLocalTime(
                     NULL,   // lpTimeZoneInformation. Use currently active time zone.
@@ -579,7 +579,8 @@ namespace ExifToolWrapper
                     std::cerr << "WARN: Local time conversion failed." << std::endl;
                 }
                 break;
-            case Local:
+            case DateTimeKind::Local:
+                /*
                 SYSTEMTIME utc;
                 if ( TzSpecificLocalTimeToSystemTime(
                     NULL,   // lpTimeZoneInformation. Use currently active time zone.
@@ -591,6 +592,7 @@ namespace ExifToolWrapper
                 } else {
                     std::cerr << "WARN: Local time conversion failed." << std::endl;
                 }
+                */
                 break;
             default:
                 // Skip any time conversion.

--- a/cpp/FileMeta/ExifToolWrapper.h
+++ b/cpp/FileMeta/ExifToolWrapper.h
@@ -54,6 +54,18 @@ For more information, please refer to <http://unlicense.org/>
 #define SET_HANDLE_INFORMATION_ERROR    -11
 #define CLOSE_HANDLE_ERROR              -12
 
+namespace DateTimeKind
+{
+    enum DateTimeKind
+    {
+        Unspecified,
+        Utc,
+        Local
+    };
+    
+    typedef enum DateTimeKind DateTimeKind;
+}
+
 namespace ExifToolWrapper
 {
     /*
@@ -76,15 +88,6 @@ namespace ExifToolWrapper
     };
     */
     
-    enum DateTimeKind
-    {
-        Unspecified,
-        Utc,
-        Local
-    };
-
-    typedef enum DateTimeKind DateTimeKind;
-    
     class ExifTool
     {
         public:
@@ -92,7 +95,7 @@ namespace ExifToolWrapper
             ~ExifTool();
             void Dispose();
             void GetProperties(const std::string filename, std::map<std::string, std::string> &propsRead) const;
-            static BOOL TryParseDate(const std::string s, const DateTimeKind kind, const LPSYSTEMTIME date);
+            static BOOL TryParseDate(const std::string s, const DateTimeKind::DateTimeKind kind, const LPSYSTEMTIME date);
             
         protected:
             void Dispose(bool disposing);

--- a/cpp/FileMeta/main.cpp
+++ b/cpp/FileMeta/main.cpp
@@ -59,7 +59,7 @@ void TestParsing()
     
     ok = ExifToolWrapper::ExifTool::TryParseDate(
         test,
-        ExifToolWrapper::DateTimeKind::Utc,
+        DateTimeKind::Utc,
         &date
     );
 
@@ -71,7 +71,7 @@ void TestParsing()
         
     ok = ExifToolWrapper::ExifTool::TryParseDate(
         test,
-        ExifToolWrapper::DateTimeKind::Local,
+        DateTimeKind::Local,
         &date
     );
 
@@ -83,7 +83,7 @@ void TestParsing()
 
     ok = ExifToolWrapper::ExifTool::TryParseDate(
         test,
-        ExifToolWrapper::DateTimeKind::Unspecified,
+        DateTimeKind::Unspecified,
         &date
     );
     


### PR DESCRIPTION
Also disabled use of `TzSpecificLocalTimeToSystemTime` which was unavailable in older `windows.h`